### PR TITLE
add override in function to fit version under v0.8.8

### DIFF
--- a/contracts/ERC721AUpgradeable.sol
+++ b/contracts/ERC721AUpgradeable.sol
@@ -70,7 +70,7 @@ contract ERC721AUpgradeable is Initializable, ContextUpgradeable, ERC165Upgradea
     /**
      * @dev Burned tokens are calculated here, use _totalMinted() if you want to count just minted tokens.
      */
-    function totalSupply() public view returns (uint256) {
+    function totalSupply() public view override returns (uint256) {
         // Counter underflow is impossible as _burnCounter cannot be incremented
         // more than _currentIndex - _startTokenId() times
         unchecked {

--- a/contracts/extensions/ERC721ABurnableUpgradeable.sol
+++ b/contracts/extensions/ERC721ABurnableUpgradeable.sol
@@ -24,7 +24,7 @@ abstract contract ERC721ABurnableUpgradeable is Initializable, ERC721AUpgradeabl
      *
      * - The caller must own `tokenId` or be an approved operator.
      */
-    function burn(uint256 tokenId) public virtual {
+    function burn(uint256 tokenId) public virtual override {
         _burn(tokenId, true);
     }
 

--- a/contracts/extensions/ERC721AQueryableUpgradeable.sol
+++ b/contracts/extensions/ERC721AQueryableUpgradeable.sol
@@ -35,7 +35,7 @@ abstract contract ERC721AQueryableUpgradeable is Initializable, ERC721AUpgradeab
      *   - `startTimestamp` = `<Timestamp of start of ownership>`
      *   - `burned = `false`
      */
-    function explicitOwnershipOf(uint256 tokenId) public view returns (TokenOwnership memory) {
+    function explicitOwnershipOf(uint256 tokenId) public view override returns (TokenOwnership memory) {
         TokenOwnership memory ownership;
         if (tokenId < _startTokenId() || tokenId >= _currentIndex) {
             return ownership;
@@ -51,7 +51,7 @@ abstract contract ERC721AQueryableUpgradeable is Initializable, ERC721AUpgradeab
      * @dev Returns an array of `TokenOwnership` structs at `tokenIds` in order.
      * See {ERC721AQueryable-explicitOwnershipOf}
      */
-    function explicitOwnershipsOf(uint256[] memory tokenIds) external view returns (TokenOwnership[] memory) {
+    function explicitOwnershipsOf(uint256[] memory tokenIds) external view override returns (TokenOwnership[] memory) {
         unchecked {
             uint256 tokenIdsLength = tokenIds.length;
             TokenOwnership[] memory ownerships = new TokenOwnership[](tokenIdsLength);
@@ -78,7 +78,7 @@ abstract contract ERC721AQueryableUpgradeable is Initializable, ERC721AUpgradeab
         address owner,
         uint256 start,
         uint256 stop
-    ) external view returns (uint256[] memory) {
+    ) external view override returns (uint256[] memory) {
         unchecked {
             if (start >= stop) revert InvalidQueryRange();
             uint256 tokenIdsIdx;
@@ -145,7 +145,7 @@ abstract contract ERC721AQueryableUpgradeable is Initializable, ERC721AUpgradeab
      * multiple smaller scans if the collection is large enough to cause
      * an out-of-gas error (10K pfp collections should be fine).
      */
-    function tokensOfOwner(address owner) external view returns (uint256[] memory) {
+    function tokensOfOwner(address owner) external view override returns (uint256[] memory) {
         unchecked {
             uint256 tokenIdsIdx;
             address currOwnershipAddr;


### PR DESCRIPTION
contract's solidity version is solidity ^0.8.4, but in code use one feature only support ^0.8.8.

https://blog.soliditylang.org/2021/09/27/solidity-0.8.8-release-announcement/

you can see No Override for Interface Functions in this article.

so to fit contract version under 0.8.8, I add override for Interface function.