### PR TITLE
Add replacements for TokenApprovalRef

### DIFF
--- a/contracts/ERC721AStorage.sol
+++ b/contracts/ERC721AStorage.sol
@@ -2,9 +2,12 @@
 
 pragma solidity ^0.8.0;
 
-import {ERC721AUpgradeable} from './ERC721AUpgradeable.sol';
-
 library ERC721AStorage {
+    // Reference type for token approval.
+    struct TokenApprovalRef {
+        address value;
+    }
+
     struct Layout {
         // =============================================================
         //                            STORAGE
@@ -38,7 +41,7 @@ library ERC721AStorage {
         // - [192..255] `aux`
         mapping(address => uint256) _packedAddressData;
         // Mapping from token ID to approved address.
-        mapping(uint256 => ERC721AUpgradeable.TokenApprovalRef) _tokenApprovals;
+        mapping(uint256 => ERC721AStorage.TokenApprovalRef) _tokenApprovals;
         // Mapping from owner to operator approvals
         mapping(address => mapping(address => bool)) _operatorApprovals;
     }

--- a/contracts/ERC721AUpgradeable.sol
+++ b/contracts/ERC721AUpgradeable.sol
@@ -37,10 +37,6 @@ interface ERC721A__IERC721ReceiverUpgradeable {
  */
 contract ERC721AUpgradeable is ERC721A__Initializable, IERC721AUpgradeable {
     using ERC721AStorage for ERC721AStorage.Layout;
-    // Reference type for token approval.
-    struct TokenApprovalRef {
-        address value;
-    }
 
     // =============================================================
     //                           CONSTANTS
@@ -480,7 +476,7 @@ contract ERC721AUpgradeable is ERC721A__Initializable, IERC721AUpgradeable {
         view
         returns (uint256 approvedAddressSlot, address approvedAddress)
     {
-        TokenApprovalRef storage tokenApproval = ERC721AStorage.layout()._tokenApprovals[tokenId];
+        ERC721AStorage.TokenApprovalRef storage tokenApproval = ERC721AStorage.layout()._tokenApprovals[tokenId];
         // The following is equivalent to `approvedAddress = _tokenApprovals[tokenId]`.
         assembly {
             approvedAddressSlot := tokenApproval.slot

--- a/scripts/replace-imports.js
+++ b/scripts/replace-imports.js
@@ -28,7 +28,7 @@ glob('contracts/**/*.sol', null, function (err, files) {
 // Replace the TokenApprovalRef to break cyclic importing.
 let erc721aFilepath = 'contracts/ERC721AUpgradeable.sol';
 let erc721aContents = fs.readFileSync(erc721aFilepath, 'utf8');
-let tokenApprovalRefRe = /\/\/.*?\n\r?\s*struct TokenApprovalRef\s*\{[^\}]+\}/;
+let tokenApprovalRefRe = /\/\/.*?\n\r?\s*struct TokenApprovalRef\s*\{[^}]+\}/;
 let tokenApprovalRefMatch = erc721aContents.match(tokenApprovalRefRe);
 if (tokenApprovalRefMatch) {
   erc721aContents = erc721aContents
@@ -43,5 +43,5 @@ if (tokenApprovalRefMatch) {
     .replace(/ERC721AUpgradeable.TokenApprovalRef/g, 'ERC721AStorage.TokenApprovalRef')
     .replace(/import.*?\.\/ERC721AUpgradeable.sol[^;]+;/, '');
   
-  fs.writeFileSync(erc721aStorageFilepath, erc721aStorageContents);    
+  fs.writeFileSync(erc721aStorageFilepath, erc721aStorageContents);
 }

--- a/scripts/replace-imports.js
+++ b/scripts/replace-imports.js
@@ -2,14 +2,14 @@
 const fs = require('fs');
 const glob = require('glob');
 
-// rename files
+// Rename files.
 fs.renameSync('contracts/Initializable.sol', 'contracts/ERC721A__Initializable.sol');
 fs.renameSync('contracts/InitializableStorage.sol', 'contracts/ERC721A__InitializableStorage.sol');
 
-// loop through all files with contracts/**/*.sol pattern
+// Loop through all files with contracts/**/*.sol pattern.
 glob('contracts/**/*.sol', null, function (err, files) {
   files.forEach((file) => {
-    // read file content
+    // Read file content.
     const content = fs.readFileSync(file, 'utf8');
 
     const updatedContent = content
@@ -20,7 +20,28 @@ glob('contracts/**/*.sol', null, function (err, files) {
       .replace(/onlyInitializing\s*?\{/g, 'onlyInitializingERC721A {')
       .replace(/Initializable/g, 'ERC721A__Initializable');
 
-    // write updated file
+    // Write updated file.
     fs.writeFileSync(file, updatedContent);
   });
 });
+
+// Replace the TokenApprovalRef to break cyclic importing.
+let erc721aFilepath = 'contracts/ERC721AUpgradeable.sol';
+let erc721aContents = fs.readFileSync(erc721aFilepath, 'utf8');
+let tokenApprovalRefRe = /\/\/.*?\n\r?\s*struct TokenApprovalRef\s*\{[^\}]+\}/;
+let tokenApprovalRefMatch = erc721aContents.match(tokenApprovalRefRe);
+if (tokenApprovalRefMatch) {
+  erc721aContents = erc721aContents
+    .replace(tokenApprovalRefMatch[0], '')
+    .replace(/TokenApprovalRef/g, 'ERC721AStorage.TokenApprovalRef');
+  fs.writeFileSync(erc721aFilepath, erc721aContents);
+
+  let erc721aStorageFilepath = 'contracts/ERC721AStorage.sol';
+  let erc721aStorageContents = fs.readFileSync(erc721aStorageFilepath, 'utf8');
+  erc721aStorageContents = erc721aStorageContents
+    .replace(/struct Layout\s*\{/, tokenApprovalRefMatch[0] + '\n\n    struct Layout {')
+    .replace(/ERC721AUpgradeable.TokenApprovalRef/g, 'ERC721AStorage.TokenApprovalRef')
+    .replace(/import.*?\.\/ERC721AUpgradeable.sol[^;]+;/, '');
+  
+  fs.writeFileSync(erc721aStorageFilepath, erc721aStorageContents);    
+}


### PR DESCRIPTION
Fixes #14. 

This regex thingy doesn't look the cleanest though, but I don't think we will ever need to touch the `TokenApprovalRef`. 

The regex is also general enough to allow for one line of comment above the struct.

I'd prefer fixing it in this repo than the main repo. Cuz the other way about it is to create a whole new .sol file with a werid name just for this one struct.

May want to do a tiny version bump from 4.2.0 -> 4.2.1 for the Upgradeable repo. 

-----

@jovijovi can you help confirm that this will fix the issue?